### PR TITLE
chore(ci): disable excessive builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.x']
+        python-version: ['3.x'] # '3.8', '3.9', '3.10',  #TODO: Disabled beacause we are reaching GitHub action quota for private repos too quickly
         poetry-version: ['1.4.2']
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest] # windows-latest TODO: Disabled beacause we are reaching GitHub action quota for private repos too quickly
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION

## Summary

Whilst this repository is still private, I am quickly reaching the GitHub Action quota. So temporarily disabling these extra builds. 

Once the repository is public, we will renable these