### PR TITLE
fix(github): ensure invalid dates become NaT

### DIFF
--- a/prfiesta/collectors/github.py
+++ b/prfiesta/collectors/github.py
@@ -160,7 +160,7 @@ class GitHubCollector:
 
     def _parse_datetime_columns(self, df: pd.DataFrame) -> pd.DataFrame:
         for col in self._datetime_columns:
-            df[col] = pd.to_datetime(df[col], errors="ignore")
+            df[col] = pd.to_datetime(df[col], errors="coerce")
         return df
 
 


### PR DESCRIPTION
## Summary

Closes #56 

`ignore` is deprecated and if you run the tool currently (with pandas `2.2.3`) you will get a future warning: 

```python
prfiesta/collectors/github.py:163: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use
to_datetime without passing `errors` and catch exceptions explicitly instead
  df[col] = pd.to_datetime(df[col], errors="ignore")
```

* To ensure backwards compatibility, instead of `raise`, we are going to just make them into `NaT` so that we don't break any downstream workflows

## References

* https://github.com/pandas-dev/pandas/issues/54467
* https://pandas.pydata.org/docs/whatsnew/v2.2.0.html