### PR TITLE
chore(ci): upgrade github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,11 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.3
 
       - uses: astral-sh/setup-uv@v8.2.0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -71,8 +71,8 @@ jobs:
     env:
       TERRAFORM_DIRECTORY: terraform
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
+      - uses: actions/checkout@v6.0.3
+      - uses: hashicorp/setup-terraform@v3.1.2
 
       - name: Terraform Init
         working-directory: ${{ env.TERRAFORM_DIRECTORY }}
@@ -94,8 +94,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6.0.3
+      - uses: astral-sh/setup-uv@v8.2.0
 
       - name: Release
         id: release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Comment (Prerelease)
         if: github.ref != 'refs/heads/main' && github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3.0.1
         with:
           message: |
             Change was prereleased to pypi. Try it out :rocket:
@@ -149,7 +149,7 @@ jobs:
 
             https://pypi.org/project/prfiesta/${{steps.prerelease.outputs.VERSION}}/
 
-          comment_tag: execution
+          comment-tag: execution
 
       # Main Release
       - name: Bump Version

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,6 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary 

Upgrade all relevant GitHub Action Plugins in the main workflow

## Changes

* Updated GitHub workflow actions to newer Node 24-compatible versions.
* Upgraded `actions/checkout` from `v3` to `v6.0.3` across the main workflow.
* Upgraded `actions/setup-python` from `v4` to `v6.2.0`.
* Upgraded `hashicorp/setup-terraform` from `v2` to `v3.1.2`.
* Aligned the release job to use `astral-sh/setup-uv@v8.2.0`, matching the build job.
* Upgraded the prerelease PR comment action to `thollander/actions-comment-pull-request@v3.0.1` and updated its renamed `comment-tag` input.
* Upgraded the PR title validation workflow to `amannn/action-semantic-pull-request@v6.1.1`.
* These updates reduce GitHub Actions deprecation warnings and keep CI compatible with GitHub’s move from Node 20 to Node 24.

## References

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/